### PR TITLE
Fix the final bug

### DIFF
--- a/Portfolio/src/assets/sass/_settings.scss
+++ b/Portfolio/src/assets/sass/_settings.scss
@@ -28,7 +28,6 @@ $bodyFont: 'Lato', sans-serif;
     --spanHoverModal: #3358D4;
 }
 
-
 [data-theme="dark"] {
     --bodyBg: #11131F;
     --bgBtn: #3E63DD;
@@ -41,19 +40,6 @@ $bodyFont: 'Lato', sans-serif;
     --spanBgModal: white;
     --spanColorModal: #182449;
     --spanHoverModal: #1D2E62;
-}
-
-@keyframes appear {
-    100% {
-        opacity: 1;
-        transform: none;
-    }
-}
-@keyframes disappear {
-    100% {
-        opacity: 0;
-        transform: translateX(1000px);
-    }
 }
 
 * {

--- a/Portfolio/src/assets/sass/components/_modal.scss
+++ b/Portfolio/src/assets/sass/components/_modal.scss
@@ -12,6 +12,7 @@
     transform: translateX(1000px);
     z-index: 1000;
     box-shadow: inset 5px 0 0 0 var(--border);
+    transition: transform 0.5s ease-in-out, opacity 0.5s ease-in-out;
 
     @media screen and (max-width: 768px) {
         overflow: scroll;
@@ -20,10 +21,12 @@
     }
 
     &.opened {
-        animation: appear 0.5s ease-out forwards;
+        opacity: 1;
+        transform: none;
     }
     &.closed {
-        animation: disappear 0.5s ease-out forwards;
+        opacity: 0;
+        transform: translateX(1000px);
     }
 
     .modal-container {

--- a/Portfolio/src/components/Projects/DisplayProject.jsx
+++ b/Portfolio/src/components/Projects/DisplayProject.jsx
@@ -9,10 +9,7 @@ export default function DisplayProject() {
 
     const selectProject = (data) => {
         setProjectSelected(data)
-
-        setTimeout(() => {
-            setIsOpen(true);
-          }, 0);
+        setIsOpen(!isOpen)
     }
     
     return (

--- a/Portfolio/src/components/Projects/ModalProject.jsx
+++ b/Portfolio/src/components/Projects/ModalProject.jsx
@@ -9,7 +9,9 @@ export default function ModalProject({ data, isOpen, setIsOpen }) {
     if (isOpen) {
         document.body.classList.add("antiScroll")
     } else {
-        document.body.classList.remove("antiScroll")
+        setTimeout(() => {
+            document.body.classList.remove("antiScroll")
+        }, 300);
     }
     
     return (


### PR DESCRIPTION
I used keyframes to animate the modal on the class "opened" and "closed". But the keyframe for "closed" didn't work. It was not a state or class issue, so instead of using keyframes I added a transition on transform and opacity on the modal and it works.
I added a setTimeOut to remove the body class "antiscroll" for the scrollbar reappear when the modal is completely closed.
And I delete an useless setTimeOut in the DisplayProject component.